### PR TITLE
Update timezone property type

### DIFF
--- a/src/KeenIO/Client/Resources/keen-io-3_0.php
+++ b/src/KeenIO/Client/Resources/keen-io-3_0.php
@@ -166,7 +166,7 @@ return array(
                 'timezone'         => array(
                     'location'    => 'query',
                     'description' => 'Modifies the timeframe filters for Relative Timeframes to match a specific timezone.',
-                    'type'        => array('string','number'),
+                    'type'        => array('string', 'number'),
                     'required'    => false,
                 ),
             ),
@@ -257,7 +257,7 @@ return array(
                 'timezone'         => array(
                     'location'    => 'query',
                     'description' => 'Modifies the timeframe filters for Relative Timeframes to match a specific timezone.',
-                    'type'        => array('string','number'),
+                    'type'        => array('string', 'number'),
                     'required'    => false,
                 ),
                 'group_by'         => array(
@@ -326,7 +326,7 @@ return array(
                 'timezone'         => array(
                     'location'    => 'query',
                     'description' => 'Modifies the timeframe filters for Relative Timeframes to match a specific timezone.',
-                    'type'        => array('string','number'),
+                    'type'        => array('string', 'number'),
                     'required'    => false,
                 ),
                 'group_by'         => array(
@@ -395,7 +395,7 @@ return array(
                 'timezone'         => array(
                     'location'    => 'query',
                     'description' => 'Modifies the timeframe filters for Relative Timeframes to match a specific timezone.',
-                    'type'        => array('string','number'),
+                    'type'        => array('string', 'number'),
                     'required'    => false,
                 ),
                 'group_by'         => array(
@@ -464,7 +464,7 @@ return array(
                 'timezone'         => array(
                     'location'    => 'query',
                     'description' => 'Modifies the timeframe filters for Relative Timeframes to match a specific timezone.',
-                    'type'        => array('string','number'),
+                    'type'        => array('string', 'number'),
                     'required'    => false,
                 ),
                 'group_by'         => array(
@@ -533,7 +533,7 @@ return array(
                 'timezone'         => array(
                     'location'    => 'query',
                     'description' => 'Modifies the timeframe filters for Relative Timeframes to match a specific timezone.',
-                    'type'        => array('string','number'),
+                    'type'        => array('string', 'number'),
                     'required'    => false,
                 ),
                 'group_by'         => array(
@@ -602,7 +602,7 @@ return array(
                 'timezone'         => array(
                     'location'    => 'query',
                     'description' => 'Modifies the timeframe filters for Relative Timeframes to match a specific timezone.',
-                    'type'        => array('string','number'),
+                    'type'        => array('string', 'number'),
                     'required'    => false,
                 ),
                 'group_by'         => array(
@@ -671,7 +671,7 @@ return array(
                 'timezone'         => array(
                     'location'    => 'query',
                     'description' => 'Modifies the timeframe filters for Relative Timeframes to match a specific timezone.',
-                    'type'        => array('string','number'),
+                    'type'        => array('string', 'number'),
                     'required'    => false,
                 ),
                 'group_by'         => array(
@@ -772,7 +772,7 @@ return array(
                 'timezone'         => array(
                     'location'    => 'query',
                     'description' => 'Modifies the timeframe filters for Relative Timeframes to match a specific timezone.',
-                    'type'        => array('string','number'),
+                    'type'        => array('string', 'number'),
                     'required'    => false,
                 ),
                 'group_by'         => array(


### PR DESCRIPTION
Currently we only allow the timezone to be a number - but Keen IO has valid, named timezones that can be passed.  

Just fixes the service description to allow the timezone to be a number or string.
