### PR TITLE
Dropping default value for __call

### DIFF
--- a/src/KeenIO/Client/KeenIOClient.php
+++ b/src/KeenIO/Client/KeenIOClient.php
@@ -85,7 +85,7 @@ class KeenIOClient extends Client
      *
      * @return mixed Returns the result of the command
      */
-    public function __call($method, $args = array())
+    public function __call($method, $args)
     {
         if (isset($args[0]) && is_string($args[0])) {
             $args[0] = array('event_collection' => $args[0]);


### PR DESCRIPTION
The `__call` method's `$args` parameter is required and will always be present as an array (http://www.php.net/manual/en/language.oop5.overloading.php#object.call), adding a default value (like `$args = array()`) is not needed and even causes problems, as described in padraic/mockery#263.

Removing this allows us to manipulate the object as expected.
