### PR TITLE
Set travis to test HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
 language: php
 php:
-  - "5.5"
-  - "5.4"
-  - "5.3"
+  - 5.5
+  - 5.4
+  - 5.3
+  - hhvm
+
+matrix:
+  allow_failures:
+    - php: hhvm
+
 before_script:
   - composer self-update
   - composer install --prefer-source


### PR DESCRIPTION
Adds `hhvm` to php versions to be tested by travis.  `hhvm` as allowed to fail in the mean time.

Adding this out of curiosity based on #64
