### PR TITLE
adding support for using default version when empty value provided

### DIFF
--- a/src/Client/KeenIOClient.php
+++ b/src/Client/KeenIOClient.php
@@ -363,7 +363,7 @@ class KeenIOClient extends Client
     protected static function parseConfig($config, $default)
     {
         array_walk($default, function ($value, $key) use (&$config) {
-            if (empty($config[$key])) {
+            if (empty($config[$key]) || !isset($config[$key])) {
                 $config[$key] = $value;
             }
         });

--- a/src/Client/KeenIOClient.php
+++ b/src/Client/KeenIOClient.php
@@ -53,6 +53,7 @@ class KeenIOClient extends Client
         );
 
         // Create client configuration
+        $config = self::parseConfig($config, $default);
         $config = Collection::fromConfig($config, $default);
 
         // Because each API Resource uses a separate type of API Key, we need to expose them all in
@@ -349,5 +350,24 @@ class KeenIOClient extends Client
         $pad = ord($string[$len - 1]);
 
         return substr($string, 0, $len - $pad);
+    }
+
+    /**
+     * Attempt to parse config and apply defaults
+     *
+     * @param  array  $config
+     * @param  array  $default
+     *
+     * @return array Returns the updated config array
+     */
+    protected static function parseConfig($config, $default)
+    {
+        array_walk($default, function ($value, $key) use (&$config) {
+            if (empty($config[$key])) {
+                $config[$key] = $value;
+            }
+        });
+
+        return $config;
     }
 }

--- a/tests/Tests/Client/KeenIOClientTest.php
+++ b/tests/Tests/Client/KeenIOClientTest.php
@@ -31,6 +31,36 @@ class KeenIOClientTest extends GuzzleTestCase
         $this->assertEquals($config['masterKey'], $client->getConfig('masterKey'));
         $this->assertEquals($config['readKey'], $client->getConfig('readKey'));
         $this->assertEquals($config['writeKey'], $client->getConfig('writeKey'));
+        $this->assertEquals($config['version'], $client->getConfig('version'));
+    }
+
+    /**
+     * Check that a Keen IO Client is instantiated properly when version empty
+     */
+    public function testFactoryReturnsClientWhenVersionEmpty()
+    {
+        $defaultVersion = '3.0';
+
+        $config = array(
+            'projectId' => 'testProjectId',
+            'masterKey' => 'testMasterKey',
+            'readKey'   => 'testReadKey',
+            'writeKey'  => 'testWriteKey',
+            'version'   => ''
+       );
+
+        $client = KeenIOClient::factory($config);
+
+        //Check that the Client is of the right type
+        $this->assertInstanceOf('\Guzzle\Service\Client', $client);
+        $this->assertInstanceOf('\KeenIO\Client\KeenIOClient', $client);
+
+        //Check that the pass config options match the client's config
+        $this->assertEquals($config['projectId'], $client->getConfig('projectId'));
+        $this->assertEquals($config['masterKey'], $client->getConfig('masterKey'));
+        $this->assertEquals($config['readKey'], $client->getConfig('readKey'));
+        $this->assertEquals($config['writeKey'], $client->getConfig('writeKey'));
+        $this->assertEquals($defaultVersion, $client->getConfig('version'));
     }
 
     /**


### PR DESCRIPTION
I uncovered a use case that caused the Client to throw errors during configuration load. If the `version` key is set, and is an empty string, in the `factory` config param, the Client will fail to load. 

I built a test to verify this behavior and it was in fact the case. 

The issue, as far as I can tell, is that the `Collection::fromConfig` method from the Guzzle 3.7 library does not check if the value is empty when merging the arrays, and as such the default version is never applied.

Instead of digging a path of resolution through Guzzle or even upgrading Guzzle within this package (I saw the other issue), I added a method that will perform an adequate check for emptiness of a common default key and assert the rule when encountered.