### PR TITLE
Crypto fixes to properly handle 64 hex char keys.

### DIFF
--- a/src/Client/KeenIOClient.php
+++ b/src/Client/KeenIOClient.php
@@ -278,12 +278,25 @@ class KeenIOClient extends Client
             $options['allowed_operations'] = $allowedOperations;
         }
 
-        $optionsJson = $this->padString(json_encode($options));
+        $apiKey = pack('H*', $masterKey);
+        $blockSize = 16;
+
+        /**
+         * Use the old block size and hex string input if using a legacy master key.
+         * Old block size was 32 bytes and old master key was 32 hex characters in length.
+         */
+
+        if (strlen($masterKey) == 32) {
+            $apiKey = $masterKey;
+            $blockSize = 32;
+        }
+
+        $optionsJson = $this->padString(json_encode($options), $blockSize);
 
         $ivLength = mcrypt_get_iv_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_CBC);
         $iv       = mcrypt_create_iv($ivLength, $source);
 
-        $encrypted = mcrypt_encrypt(MCRYPT_RIJNDAEL_128, $masterKey, $optionsJson, MCRYPT_MODE_CBC, $iv);
+        $encrypted = mcrypt_encrypt(MCRYPT_RIJNDAEL_128, $apiKey, $optionsJson, MCRYPT_MODE_CBC, $iv);
 
         $ivHex        = bin2hex($iv);
         $encryptedHex = bin2hex($encrypted);

--- a/src/Client/KeenIOClient.php
+++ b/src/Client/KeenIOClient.php
@@ -335,6 +335,13 @@ class KeenIOClient extends Client
             throw new RuntimeException('A master key is needed to decrypt a scoped key');
         }
 
+        $apiKey = pack('H*', $masterKey);
+
+        // Use the old hex string input if using a legacy master key
+        if (strlen($masterKey) == 32) {
+            $apiKey = $masterKey;
+        }
+
         $ivLength = mcrypt_get_iv_size(MCRYPT_RIJNDAEL_128, MCRYPT_MODE_CBC) * 2;
         $ivHex    = substr($scopedKey, 0, $ivLength);
 
@@ -342,7 +349,7 @@ class KeenIOClient extends Client
 
         $resultPadded = mcrypt_decrypt(
             MCRYPT_RIJNDAEL_128,
-            $masterKey,
+            $apiKey,
             pack('H*', $encryptedHex),
             MCRYPT_MODE_CBC,
             pack('H*', $ivHex)

--- a/tests/Tests/Client/KeenIOClientTest.php
+++ b/tests/Tests/Client/KeenIOClientTest.php
@@ -110,10 +110,31 @@ class KeenIOClientTest extends GuzzleTestCase
     /**
      * Tests the creation of a Scoped Key
      */
-    public function testCreateScopedKey()
+    public function testCreateLegacyScopedKey()
     {
         $client = KeenIOClient::factory(array(
             'masterKey' => 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+        ));
+
+        $filter = array('property_name' => 'id', 'operator' => 'eq', 'property_value' => '123');
+        $filters = array($filter);
+        $allowed_operations = array('read');
+
+        $scopedKey = $client->createScopedKey($filters, $allowed_operations);
+
+        $result = $client->decryptScopedKey($scopedKey);
+        $expected = array('filters' => $filters, 'allowed_operations' => $allowed_operations);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Tests the creation of a Scoped Key
+     */
+    public function testCreateScopedKey()
+    {
+        $client = KeenIOClient::factory(array(
+            'masterKey' => 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
         ));
 
         $filter = array('property_name' => 'id', 'operator' => 'eq', 'property_value' => '123');


### PR DESCRIPTION
Yes, MCRYPT_RIJNDAEL_128 with a 32 byte key is AES-256.