### PR TITLE
Fix the decoding of JSON values

### DIFF
--- a/src/Client/KeenIOClient.php
+++ b/src/Client/KeenIOClient.php
@@ -76,7 +76,7 @@ class KeenIOClient extends GuzzleClient
             null,
             function($arg)
             {
-                return json_decode($arg->getBody());
+                return json_decode($arg->getBody(), true);
             },
             null,
             $config
@@ -440,14 +440,14 @@ class KeenIOClient extends GuzzleClient
 
         if (isset($args[0]) && is_string($args[0])) {
             $formattedArgs['event_collection'] = $args[0];
-            
+
             if(isset($args[1]) && is_array($args[1])) {
                 $formattedArgs = array_merge($formattedArgs, $args[1]);
             }
         } elseif (isset($args[0]) && is_array($args[0])) {
             $formattedArgs = $args[0];
         }
-        
+
         return $formattedArgs;
     }
 

--- a/tests/Tests/Client/KeenIOClientTest.php
+++ b/tests/Tests/Client/KeenIOClientTest.php
@@ -80,9 +80,9 @@ class KeenIOClientTest extends \PHPUnit_Framework_TestCase
 		$unmergedAfter = $this->invokeMethod($client, 'combineEventCollectionArgs', array($unmerged));
 		$mergedAfter = $this->invokeMethod($client, 'combineEventCollectionArgs', array($merged));
 
-        $this->assertEquals($unmergedAfter['event_collection'], 'collection'); 
+        $this->assertEquals($unmergedAfter['event_collection'], 'collection');
 		$this->assertEquals($unmergedAfter['timeframe'], 'this_14_days');
-        $this->assertEquals($mergedAfter['event_collection'], 'collection'); 
+        $this->assertEquals($mergedAfter['event_collection'], 'collection');
 		$this->assertEquals($mergedAfter['timeframe'], 'this_14_days');
     }
 
@@ -224,13 +224,13 @@ class KeenIOClientTest extends \PHPUnit_Framework_TestCase
     public function testServiceCommands($method, $params)
     {
         $queue = new MockHandler([
-            new Response(200, [], '{response: true}')
+            new Response(200, ['Content-Type' => 'application/json'], '{"response": true}')
         ]);
         $handler = HandlerStack::create($queue);
         $client = $this->getClient($handler);
 
         $command = $client->getCommand($method, $params);
-        $client->execute($command);
+        $result = $client->execute($command);
         $request = $queue->getLastRequest();
 
         //Resource Url
@@ -254,6 +254,9 @@ class KeenIOClientTest extends \PHPUnit_Framework_TestCase
 
         //Check that the querystring has all the parameters
         $this->assertEquals($params, $queryString);
+
+        // Make sure that the response is a PHP array, according to the documented return type
+        $this->assertInternalType('array', $result);
     }
 
     /**


### PR DESCRIPTION
The documented API of the SDK is to return an array. But the decoding was changed to using stdClass for JSON objects when upgrading to Guzzle 6, which is not good in patch releases (and was probably a bug as the documented API was not updated to reflect it).

We were affected by that as our code performing queries broke due to this change (`selectUnique` does not return an array with a `result` key anymore in 2.5.7).