### PR TITLE
PR #113 addendum: remove mcrypt parameter

### DIFF
--- a/src/Client/KeenIOClient.php
+++ b/src/Client/KeenIOClient.php
@@ -296,11 +296,10 @@ class KeenIOClient extends GuzzleClient
      *
      * @param array  $filters           What filters to encode into a scoped key
      * @param array  $allowedOperations What operations the generated scoped key will allow
-     * @param int    $source
      * @return string
      * @throws RuntimeException If no master key is set
      */
-    public function createScopedKey($filters, $allowedOperations, $source = MCRYPT_DEV_URANDOM)
+    public function createScopedKey($filters, $allowedOperations)
     {
         if (!$masterKey = $this->getMasterKey()) {
             throw new RuntimeException('A master key is needed to create a scoped key');


### PR DESCRIPTION
The `$scope` parameter is no longer used by `createScopedKey`, and the value was specific to `mcrypt`, which we're removing our dependency on.

This removes the parameter since it no longer applies, and implicitly depends on `mcrypt` being available, which won't be the case in the future.

This will be a breaking changes since the API surface has changed, so that's a major version bump.