### PR TITLE
Version 2.5.10

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+VERSION 2.5.10
+-------------
+* Remove mcrypt dependency (deprecated in PHP 7.1) and replace it with openssl for scoped key support.
+
 VERSION 2.5.9
 -------------
 * Update the querying methods to use a POST request instead of a GET request

--- a/src/Client/KeenIOClient.php
+++ b/src/Client/KeenIOClient.php
@@ -40,7 +40,7 @@ use KeenIO\Exception\RuntimeException;
 class KeenIOClient extends GuzzleClient
 {
 
-    const VERSION = '2.5.9';
+    const VERSION = '2.5.10';
 
     /**
      * Factory to create new KeenIOClient instance.


### PR DESCRIPTION
Includes changes to move from mcrypt to openssl.

I made this a patch release since in theory clients should not be broken by changes to the SDK. A parameter on `createScopedKey` was removed, but PHP allows more parameters to be added at a call site than are specified in the prototype, so that shouldn't break clients.

I would be interested to know if anyone feels a major release is appropriate since the package dependencies have changed.