### PR TITLE
Arrays in POST body should not be json encoded to strings

### DIFF
--- a/src/Client/Resources/keen-io-3_0.php
+++ b/src/Client/Resources/keen-io-3_0.php
@@ -499,7 +499,6 @@ return array(
                     'description' => 'A Timeframe specifies the events to use for analysis based on a window of time. '
                                     . 'If no timeframe is specified, all events will be counted.',
                     'type'        => array('string', 'array'),
-                    'filters'     => array('KeenIO\Client\Filter\MultiTypeFiltering::encodeValue'),
                     'required'    => false,
                 ),
                 'interval'         => array(
@@ -521,7 +520,6 @@ return array(
                     'description' => 'The group_by parameter specifies the name of a property by which you would '
                                     . 'like to group the results.',
                     'type'        => array('string', 'array'),
-                    'filters'     => array('KeenIO\Client\Filter\MultiTypeFiltering::encodeValue'),
                     'required'    => false,
                 ),
             ),
@@ -570,7 +568,6 @@ return array(
                     'description' => 'A Timeframe specifies the events to use for analysis based on a window of time. '
                                     . 'If no timeframe is specified, all events will be counted.',
                     'type'        => array('string', 'array'),
-                    'filters'     => array('KeenIO\Client\Filter\MultiTypeFiltering::encodeValue'),
                     'required'    => false,
                 ),
                 'interval'         => array(
@@ -592,7 +589,6 @@ return array(
                     'description' => 'The group_by parameter specifies the name of a property by which you would '
                                     . 'like to group the results.',
                     'type'        => array('string', 'array'),
-                    'filters'     => array('KeenIO\Client\Filter\MultiTypeFiltering::encodeValue'),
                     'required'    => false,
                 ),
             ),
@@ -642,7 +638,6 @@ return array(
                     'description' => 'A Timeframe specifies the events to use for analysis based on a window of time. '
                                     . 'If no timeframe is specified, all events will be counted.',
                     'type'        => array('string', 'array'),
-                    'filters'     => array('KeenIO\Client\Filter\MultiTypeFiltering::encodeValue'),
                     'required'    => false,
                 ),
                 'interval'         => array(
@@ -664,7 +659,6 @@ return array(
                     'description' => 'The group_by parameter specifies the name of a property by which you would '
                                     . 'like to group the results.',
                     'type'        => array('string', 'array'),
-                    'filters'     => array('KeenIO\Client\Filter\MultiTypeFiltering::encodeValue'),
                     'required'    => false,
                 ),
             ),
@@ -714,7 +708,6 @@ return array(
                     'description' => 'A Timeframe specifies the events to use for analysis based on a window of time. '
                                     . 'If no timeframe is specified, all events will be counted.',
                     'type'        => array('string', 'array'),
-                    'filters'     => array('KeenIO\Client\Filter\MultiTypeFiltering::encodeValue'),
                     'required'    => false,
                 ),
                 'interval'         => array(
@@ -736,7 +729,6 @@ return array(
                     'description' => 'The group_by parameter specifies the name of a property by which you would like '
                                     . 'to group the results.',
                     'type'        => array('string', 'array'),
-                    'filters'     => array('KeenIO\Client\Filter\MultiTypeFiltering::encodeValue'),
                     'required'    => false,
                 ),
             ),
@@ -786,7 +778,6 @@ return array(
                     'description' => 'A Timeframe specifies the events to use for analysis based on a window of '
                                     . 'time. If no timeframe is specified, all events will be counted.',
                     'type'        => array('string', 'array'),
-                    'filters'     => array('KeenIO\Client\Filter\MultiTypeFiltering::encodeValue'),
                     'required'    => false,
                 ),
                 'interval'         => array(
@@ -808,7 +799,6 @@ return array(
                     'description' => 'The group_by parameter specifies the name of a property by which you would like '
                                     . 'to group the results.',
                     'type'        => array('string', 'array'),
-                    'filters'     => array('KeenIO\Client\Filter\MultiTypeFiltering::encodeValue'),
                     'required'    => false,
                 ),
             ),
@@ -858,7 +848,6 @@ return array(
                     'description' => 'A Timeframe specifies the events to use for analysis based on a window of time. '
                                     . 'If no timeframe is specified, all events will be counted.',
                     'type'        => array('string', 'array'),
-                    'filters'     => array('KeenIO\Client\Filter\MultiTypeFiltering::encodeValue'),
                     'required'    => false,
                 ),
                 'interval'         => array(
@@ -880,7 +869,6 @@ return array(
                     'description' => 'The group_by parameter specifies the name of a property by which you would like '
                                     . 'to group the results.',
                     'type'        => array('string', 'array'),
-                    'filters'     => array('KeenIO\Client\Filter\MultiTypeFiltering::encodeValue'),
                     'required'    => false,
                 ),
             ),
@@ -929,7 +917,6 @@ return array(
                     'description' => 'A Timeframe specifies the events to use for analysis based on a window of time. '
                                     . 'If no timeframe is specified, all events will be counted.',
                     'type'        => array('string', 'array'),
-                    'filters'     => array('KeenIO\Client\Filter\MultiTypeFiltering::encodeValue'),
                     'required'    => false,
                 ),
                 'interval'         => array(
@@ -951,7 +938,6 @@ return array(
                     'description' => 'The group_by parameter specifies the name of a property by which you would '
                                     . 'like to group the results.',
                     'type'        => array('string', 'array'),
-                    'filters'     => array('KeenIO\Client\Filter\MultiTypeFiltering::encodeValue'),
                     'required'    => false,
                 ),
             ),
@@ -1026,7 +1012,6 @@ return array(
                     'description' => 'A Timeframe specifies the events to use for analysis based on a window of time. '
                                     . 'If no timeframe is specified, all events will be counted.',
                     'type'        => array('string', 'array'),
-                    'filters'     => array('KeenIO\Client\Filter\MultiTypeFiltering::encodeValue'),
                     'required'    => false,
                 ),
                 'interval'         => array(
@@ -1048,7 +1033,6 @@ return array(
                     'description' => 'The group_by parameter specifies the name of a property by which you would '
                                     . 'like to group the results.',
                     'type'        => array('string', 'array'),
-                    'filters'     => array('KeenIO\Client\Filter\MultiTypeFiltering::encodeValue'),
                     'required'    => false,
                 ),
             ),
@@ -1094,7 +1078,6 @@ return array(
                     'description' => 'A Timeframe specifies the events to use for analysis based on a window of time. '
                                     . 'If no timeframe is specified, all events will be counted.',
                     'type'        => array('string', 'array'),
-                    'filters'     => array('KeenIO\Client\Filter\MultiTypeFiltering::encodeValue'),
                     'required'    => false,
                 ),
                 'email'            => array(
@@ -1163,7 +1146,6 @@ return array(
                     'description' => 'A Timeframe specifies the events to use for analysis based on a window of time. '
                                     . 'If no timeframe is specified, all events will be counted.',
                     'type'        => array('string', 'array'),
-                    'filters'     => array('KeenIO\Client\Filter\MultiTypeFiltering::encodeValue'),
                     'required'    => false,
                 ),
                 'interval'         => array(
@@ -1185,7 +1167,6 @@ return array(
                     'description' => 'The group_by parameter specifies the name of a property by which you would '
                                     . 'like to group the results.',
                     'type'        => array('string', 'array'),
-                    'filters'     => array('KeenIO\Client\Filter\MultiTypeFiltering::encodeValue'),
                     'required'    => false,
                 ),
             ),
@@ -1235,7 +1216,6 @@ return array(
                     'description' => 'A Timeframe specifies the events to use for analysis based on a window of time. '
                                     . ' If no timeframe is specified, all events will be counted.',
                     'type'        => array('string', 'array'),
-                    'filters'     => array('KeenIO\Client\Filter\MultiTypeFiltering::encodeValue'),
                     'required'    => false,
                 ),
                 'interval'         => array(
@@ -1257,7 +1237,6 @@ return array(
                     'description' => 'The group_by parameter specifies the name of a property by which you would like '
                                     . 'to group the results.',
                     'type'        => array('string', 'array'),
-                    'filters'     => array('KeenIO\Client\Filter\MultiTypeFiltering::encodeValue'),
                     'required'    => false,
                 ),
                 'percentile'         => array(


### PR DESCRIPTION
POST body parameters should not be json encoded by a filter, which converts the array to a json encoded string.