### PR TITLE
add phpdoc on the overriden getCommand method

### DIFF
--- a/src/Client/KeenIOClient.php
+++ b/src/Client/KeenIOClient.php
@@ -2,6 +2,7 @@
 
 namespace KeenIO\Client;
 
+use GuzzleHttp\Command\CommandInterface;
 use GuzzleHttp\Command\Guzzle\GuzzleClient;
 use GuzzleHttp\Command\Guzzle\Description;
 use GuzzleHttp\Client;
@@ -100,6 +101,12 @@ class KeenIOClient extends GuzzleClient
         return parent::__call($method, array($this->combineEventCollectionArgs($args)));
     }
 
+    /**
+     * @param string               $name
+     * @param array<string, mixed> $args
+     *
+     * @return CommandInterface
+     */
     public function getCommand($name, array $params = [])
     {
         $params['projectId'] = $this->getConfig('projectId');


### PR DESCRIPTION
Symfony's DebugClassLoader is triggering a deprecation warning when a method is overridden in a different package without either adding a native return type or an explicit `@return` phpdoc. This is done to push subclasses to add native return types (as they must do it before their parent), with the `@return` working as an opt-out.

Adding this phpdoc avoids getting such deprecation warning in Symfony projects:

```
Method "GuzzleHttp\Command\Guzzle\GuzzleClient::getCommand()" might add "CommandInterface" as a native return
type declaration in the future. Do the same in child class "KeenIO\Client\KeenIOClient" now to avoid errors or
add an explicit @return annotation to suppress this message.
```