### PR TITLE
Move php_codesniffer to dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
         "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "guzzlehttp/guzzle-services": "^1.0",
         "php": ">=5.6.0",
-        "squizlabs/php_codesniffer": "^3.5",
         "paragonie/random_compat": "^1.4 || ^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.27 || ^8.5.32 || ^9.6.3",
+        "squizlabs/php_codesniffer": "^3.5",
         "yoast/phpunit-polyfills": "^1.0"
     },
     "homepage": "http://keen.io",


### PR DESCRIPTION
There is no reason to depend on it in projects using this SDK.