### PR TITLE
Fix the client when used with guzzle 7.9

### DIFF
--- a/src/Client/KeenIOClient.php
+++ b/src/Client/KeenIOClient.php
@@ -72,9 +72,20 @@ class KeenIOClient extends GuzzleClient
 
         $file = 'keen-io-' . str_replace('.', '_', $config['version']) . '.php';
 
+        $guzzleClientConfig = $config;
+        unset(
+            $guzzleClientConfig['masterKey'],
+            $guzzleClientConfig['writeKey'],
+            $guzzleClientConfig['readKey'],
+            $guzzleClientConfig['projectId'],
+            $guzzleClientConfig['organizationKey'],
+            $guzzleClientConfig['organizationId'],
+            $guzzleClientConfig['version']
+        );
+
         // Create the new Keen IO Client with our Configuration
         return new self(
-            new Client($config),
+            new Client($guzzleClientConfig),
             new Description(include __DIR__ . "/Resources/{$file}"),
             null,
             function ($arg) {


### PR DESCRIPTION
Guzzle 7.9 introduces stricter checks on the protocol version. This protocol version is configured through the `version` config option. As the whole KeenIOClient config was passed to the instantiated Guzzle Client, this broke things because the version of the keen service was passed to Guzzle as the version config as well, while totally unrelated. The updated logic removes all config options corresponding to the KeenIOClient from the options passed to the Guzzle client.